### PR TITLE
Revert to before the prettified output feature

### DIFF
--- a/src/power_assert.cr
+++ b/src/power_assert.cr
@@ -46,7 +46,7 @@ module PowerAssert
       io << " " * PowerAssert.config.global_indent
 
       main_value = breakdowns.first
-      main_range = main_value.indent ... (main_value.indent + main_value.value.length + 4)
+      main_range = main_value.indent ... (main_value.indent + main_value.value.length)
 
       if only_bars
         main_value = nil
@@ -60,13 +60,12 @@ module PowerAssert
         wrote += point
         if !main_range.includes?(breakdown.indent) && breakdown != main_value
           io << " " * point
-          io << "│"
-          wrote += 2
+          io << "|"
+          wrote += 1
         elsif breakdown == main_value && main_value
           io << " " * point
-          io << "└ "
           io << main_value.value
-          wrote += main_value.value.length + 3
+          wrote += main_value.value.length
         else
           wrote -= point
           overlap = true


### PR DESCRIPTION
Although the prettified output is nice feature, it seems strongly depending on each environment that how lines are displayed on a screen. In my case, on some machines/applications the display looks fine (especially on application in which `│` is displayed as a Zenkaku), but on others it gets corrupted like the following:

``` text
example.falsey(one, two, three)
│      │     │   │   │
│      └ false    │   │
│             │   │   │
│             └ 1 │   │
│                  └ 2 │
│                       └ 3
└ #<PowerAssert::Example:0x105230eb0>
```
## update 2015-08-24 15:00

I don't know exactly why this problem occurs, but maybe how `│` (U+2502) is displayed is following to each application's "East Asian Width" setting, so I would like to offer a suggestion to revert the implementation to the one before you adding the prettified output feature. How does it sound to you?
